### PR TITLE
Add send_message and force_update services

### DIFF
--- a/custom_components/one2track/__init__.py
+++ b/custom_components/one2track/__init__.py
@@ -14,6 +14,7 @@ from .common import (
     LOGGER
 )
 from .coordinator import GpsCoordinator
+from .services import async_setup_services, async_unload_services
 
 PLATFORMS = [Platform.DEVICE_TRACKER, Platform.SENSOR, Platform.BINARY_SENSOR]
 
@@ -44,6 +45,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     }
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    await async_setup_services(hass)
 
     return True
 
@@ -53,5 +55,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id)
+        if not hass.data[DOMAIN]:
+            await async_unload_services(hass)
 
     return unload_ok

--- a/custom_components/one2track/services.py
+++ b/custom_components/one2track/services.py
@@ -24,7 +24,19 @@ def _resolve_device_uuid(hass: HomeAssistant, entity_ids: list[str]) -> str:
     for entity_id in entity_ids:
         entry = registry.async_get(entity_id)
         if entry and entry.platform == DOMAIN:
-            return entry.unique_id
+            unique_id = entry.unique_id
+            # device_tracker unique_id is the raw UUID, but sensor entities
+            # use {uuid}_{key} format — match against known device UUIDs
+            for entry_data in hass.data.get(DOMAIN, {}).values():
+                if not isinstance(entry_data, dict):
+                    continue
+                coordinator = entry_data.get("coordinator")
+                if coordinator and coordinator.data:
+                    for device in coordinator.data:
+                        if unique_id == device.get("uuid") or unique_id.startswith(device.get("uuid", "") + "_"):
+                            return device["uuid"]
+            # Fall back to raw unique_id if no coordinator match
+            return unique_id
 
     raise HomeAssistantError(f"Could not resolve One2Track device from {entity_ids}")
 

--- a/custom_components/one2track/services.py
+++ b/custom_components/one2track/services.py
@@ -1,0 +1,108 @@
+import logging
+from typing import List
+
+import voluptuous as vol
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
+
+from .client import GpsClient, TrackerDevice
+from .common import DOMAIN
+from .coordinator import GpsCoordinator
+
+LOGGER = logging.getLogger(__name__)
+
+SERVICE_SEND_MESSAGE = "send_message"
+SERVICE_FORCE_UPDATE = "force_update"
+ATTR_MESSAGE = "message"
+
+
+def _resolve_device_uuid(hass: HomeAssistant, entity_ids: list[str]) -> str:
+    """Resolve a target entity ID to a One2Track device UUID."""
+    registry = er.async_get(hass)
+
+    for entity_id in entity_ids:
+        entry = registry.async_get(entity_id)
+        if entry and entry.platform == DOMAIN:
+            return entry.unique_id
+
+    raise HomeAssistantError(f"Could not resolve One2Track device from {entity_ids}")
+
+
+def _get_client_for_uuid(hass: HomeAssistant, device_uuid: str) -> GpsClient:
+    """Find the API client that manages a given device UUID."""
+    for entry_data in hass.data.get(DOMAIN, {}).values():
+        if not isinstance(entry_data, dict):
+            continue
+        coordinator: GpsCoordinator = entry_data.get("coordinator")
+        if coordinator and coordinator.data:
+            devices: List[TrackerDevice] = coordinator.data
+            for device in devices:
+                if device.get("uuid") == device_uuid:
+                    return entry_data["api_client"]
+
+    raise HomeAssistantError(f"No One2Track client found for device {device_uuid}")
+
+
+async def async_setup_services(hass: HomeAssistant) -> None:
+    """Set up One2Track services."""
+
+    async def handle_send_message(call: ServiceCall) -> None:
+        entity_ids = call.data.get("entity_id", [])
+        if isinstance(entity_ids, str):
+            entity_ids = [entity_ids]
+
+        message = call.data[ATTR_MESSAGE]
+        device_uuid = _resolve_device_uuid(hass, entity_ids)
+        client = _get_client_for_uuid(hass, device_uuid)
+
+        LOGGER.info("Sending message to %s: %s", device_uuid, message)
+        success = await client.send_message(device_uuid, message)
+        if not success:
+            raise HomeAssistantError("Failed to send message to One2Track device")
+
+    async def handle_force_update(call: ServiceCall) -> None:
+        entity_ids = call.data.get("entity_id", [])
+        if isinstance(entity_ids, str):
+            entity_ids = [entity_ids]
+
+        device_uuid = _resolve_device_uuid(hass, entity_ids)
+        client = _get_client_for_uuid(hass, device_uuid)
+
+        LOGGER.info("Requesting force update for %s", device_uuid)
+        success = await client.force_update(device_uuid)
+        if not success:
+            raise HomeAssistantError("Failed to activate positioning mode on One2Track device")
+
+        # Refresh coordinator data after a delay to pick up new location
+        for entry_data in hass.data.get(DOMAIN, {}).values():
+            if not isinstance(entry_data, dict):
+                continue
+            coordinator: GpsCoordinator = entry_data.get("coordinator")
+            if coordinator:
+                await coordinator.async_request_refresh()
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SEND_MESSAGE,
+        handle_send_message,
+        schema=vol.Schema({
+            vol.Optional("entity_id"): vol.Any(str, [str]),
+            vol.Required(ATTR_MESSAGE): str,
+        }),
+    )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_FORCE_UPDATE,
+        handle_force_update,
+        schema=vol.Schema({
+            vol.Optional("entity_id"): vol.Any(str, [str]),
+        }),
+    )
+
+
+async def async_unload_services(hass: HomeAssistant) -> None:
+    """Unload One2Track services."""
+    hass.services.async_remove(DOMAIN, SERVICE_SEND_MESSAGE)
+    hass.services.async_remove(DOMAIN, SERVICE_FORCE_UPDATE)

--- a/custom_components/one2track/services.py
+++ b/custom_components/one2track/services.py
@@ -60,6 +60,8 @@ def _get_client_for_uuid(hass: HomeAssistant, device_uuid: str) -> GpsClient:
 
 async def async_setup_services(hass: HomeAssistant) -> None:
     """Set up One2Track services."""
+    if hass.services.has_service(DOMAIN, SERVICE_SEND_MESSAGE):
+        return
 
     async def handle_send_message(call: ServiceCall) -> None:
         entity_ids = call.data.get("entity_id", [])

--- a/custom_components/one2track/services.py
+++ b/custom_components/one2track/services.py
@@ -1,5 +1,4 @@
 import logging
-from typing import List
 
 import voluptuous as vol
 from homeassistant.core import HomeAssistant, ServiceCall
@@ -19,6 +18,9 @@ ATTR_MESSAGE = "message"
 
 def _resolve_device_uuid(hass: HomeAssistant, entity_ids: list[str]) -> str:
     """Resolve a target entity ID to a One2Track device UUID."""
+    if not entity_ids:
+        raise HomeAssistantError("No target entity specified")
+
     registry = er.async_get(hass)
 
     for entity_id in entity_ids:
@@ -48,7 +50,7 @@ def _get_client_for_uuid(hass: HomeAssistant, device_uuid: str) -> GpsClient:
             continue
         coordinator: GpsCoordinator = entry_data.get("coordinator")
         if coordinator and coordinator.data:
-            devices: List[TrackerDevice] = coordinator.data
+            devices: list[TrackerDevice] = coordinator.data
             for device in devices:
                 if device.get("uuid") == device_uuid:
                     return entry_data["api_client"]
@@ -86,7 +88,6 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         if not success:
             raise HomeAssistantError("Failed to activate positioning mode on One2Track device")
 
-        # Refresh coordinator data after a delay to pick up new location
         for entry_data in hass.data.get(DOMAIN, {}).values():
             if not isinstance(entry_data, dict):
                 continue
@@ -99,7 +100,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         SERVICE_SEND_MESSAGE,
         handle_send_message,
         schema=vol.Schema({
-            vol.Optional("entity_id"): vol.Any(str, [str]),
+            vol.Required("entity_id"): vol.Any(str, [str]),
             vol.Required(ATTR_MESSAGE): str,
         }),
     )
@@ -109,7 +110,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         SERVICE_FORCE_UPDATE,
         handle_force_update,
         schema=vol.Schema({
-            vol.Optional("entity_id"): vol.Any(str, [str]),
+            vol.Required("entity_id"): vol.Any(str, [str]),
         }),
     )
 

--- a/custom_components/one2track/services.yaml
+++ b/custom_components/one2track/services.yaml
@@ -1,1 +1,23 @@
-# TODO: Add service to push message
+send_message:
+  name: Send message
+  description: Send a text message to a One2Track device
+  target:
+    entity:
+      integration: one2track
+      domain: device_tracker
+  fields:
+    message:
+      name: Message
+      description: The text message to send to the device
+      required: true
+      example: "Time to come home!"
+      selector:
+        text:
+
+force_update:
+  name: Force update
+  description: Activate positioning mode on a One2Track device for ~2 minutes
+  target:
+    entity:
+      integration: one2track
+      domain: device_tracker


### PR DESCRIPTION
## Problem

The integration is read-only. Users can't send messages to their watch or trigger a fresh location update from Home Assistant.

## Solution

Two new services:

- **`one2track.send_message`** — send a text message to a device (uses `/devices/{uuid}/messages` endpoint)
- **`one2track.force_update`** — activate positioning mode for ~2 minutes (uses `/api/devices/{uuid}/functions` with code `0039`)

Both target device tracker entities and resolve to the device UUID automatically. Force update triggers a coordinator refresh to pick up the new location data.

> **Note:** This PR depends on #11 (infrastructure refactor). The diff currently includes those changes — it will auto-shrink after #11 is merged.