### PR TITLE
Fix login cookie handling + add power_off service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 debug
 .idea
 .context/
+__pycache__/
+*.pyc
+.venv/
+uv.lock
+.pytest_cache/

--- a/custom_components/one2track/__init__.py
+++ b/custom_components/one2track/__init__.py
@@ -1,18 +1,12 @@
 from aiohttp import ClientError
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.const import Platform
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .client import get_client, One2TrackConfig, AuthenticationError
-from .common import (
-    CONF_USER_NAME,
-    CONF_PASSWORD,
-    CONF_ID,
-    DOMAIN,
-    LOGGER
-)
+from .client import AuthenticationError, One2TrackConfig, get_client
+from .common import CONF_ID, CONF_PASSWORD, CONF_USER_NAME, DOMAIN, LOGGER
 from .coordinator import GpsCoordinator
 from .services import async_setup_services, async_unload_services
 
@@ -23,7 +17,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up One2Track Data from a config entry."""
 
     session = async_get_clientsession(hass)
-    config = One2TrackConfig(username=entry.data[CONF_USER_NAME], password=entry.data[CONF_PASSWORD], id=entry.data[CONF_ID])
+    config = One2TrackConfig(
+        username=entry.data[CONF_USER_NAME],
+        password=entry.data[CONF_PASSWORD],
+        id=entry.data[CONF_ID],
+    )
     api = get_client(config, session)
     try:
         account_id = await api.install()
@@ -32,7 +30,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         raise ConfigEntryNotReady from ex
 
     if account_id != entry.data[CONF_ID]:
-        LOGGER.error("Unexpected initial account id: %s. Expected: %s", account_id, entry.data[CONF_ID])
+        LOGGER.error(
+            "Unexpected initial account id: %s. Expected: %s",
+            account_id,
+            entry.data[CONF_ID],
+        )
         raise ConfigEntryNotReady
 
     coordinator = GpsCoordinator(hass, api)
@@ -40,8 +42,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = {
-        'api_client': api,
-        'coordinator': coordinator,
+        "api_client": api,
+        "coordinator": coordinator,
     }
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/custom_components/one2track/binary_sensor.py
+++ b/custom_components/one2track/binary_sensor.py
@@ -18,18 +18,16 @@ LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
-        hass: HomeAssistant,
-        entry: ConfigEntry,
-        async_add_entities: AddEntitiesCallback,
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up One2Track binary sensor entities."""
-    coordinator: GpsCoordinator = hass.data[DOMAIN][entry.entry_id]['coordinator']
+    coordinator: GpsCoordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
 
     devices: list[TrackerDevice] = coordinator.data or []
 
-    async_add_entities(
-        [One2TrackTumbleSensor(coordinator, device) for device in devices]
-    )
+    async_add_entities([One2TrackTumbleSensor(coordinator, device) for device in devices])
 
 
 class One2TrackTumbleSensor(CoordinatorEntity, BinarySensorEntity):
@@ -40,9 +38,9 @@ class One2TrackTumbleSensor(CoordinatorEntity, BinarySensorEntity):
     _attr_device_class = BinarySensorDeviceClass.SAFETY
 
     def __init__(
-            self,
-            coordinator: GpsCoordinator,
-            device: TrackerDevice,
+        self,
+        coordinator: GpsCoordinator,
+        device: TrackerDevice,
     ) -> None:
         super().__init__(coordinator)
         self._device = device
@@ -51,9 +49,9 @@ class One2TrackTumbleSensor(CoordinatorEntity, BinarySensorEntity):
     @property
     def device_info(self) -> DeviceInfo:
         return DeviceInfo(
-            identifiers={(DOMAIN, self._device['uuid'])},
-            serial_number=self._device['serial_number'],
-            name=self._device['name'],
+            identifiers={(DOMAIN, self._device["uuid"])},
+            serial_number=self._device["serial_number"],
+            name=self._device["name"],
         )
 
     @property
@@ -67,7 +65,7 @@ class One2TrackTumbleSensor(CoordinatorEntity, BinarySensorEntity):
     def _handle_coordinator_update(self) -> None:
         new_data: list[TrackerDevice] = self.coordinator.data
         if new_data:
-            me = next((x for x in new_data if x['uuid'] == self._device['uuid']), None)
+            me = next((x for x in new_data if x["uuid"] == self._device["uuid"]), None)
             if me:
                 self._device = me
         self.async_write_ha_state()

--- a/custom_components/one2track/client/__init__.py
+++ b/custom_components/one2track/client/__init__.py
@@ -1,7 +1,9 @@
 from aiohttp import ClientSession
 
-from .gps_client import GpsClient
-from .client_types import One2TrackConfig, AuthenticationError, TrackerDevice
+from .client_types import AuthenticationError as AuthenticationError
+from .client_types import One2TrackConfig as One2TrackConfig
+from .client_types import TrackerDevice as TrackerDevice
+from .gps_client import GpsClient as GpsClient
 
 
 def get_client(config: One2TrackConfig, session: ClientSession) -> GpsClient:

--- a/custom_components/one2track/client/client_types.py
+++ b/custom_components/one2track/client/client_types.py
@@ -2,15 +2,10 @@ from typing import NamedTuple, TypedDict
 
 
 class AuthenticationError(Exception):
-    """This error is thrown when Authentication fails, which can mean the username/password or domain is incorrect"""
+    """Authentication failed (wrong username/password or domain)."""
 
 
 class One2TrackConfig(NamedTuple):
-    """
-    This is our config for logging into One2Track
-
-    """
-
     username: str
     password: str
     id: str | None = None

--- a/custom_components/one2track/client/gps_client.py
+++ b/custom_components/one2track/client/gps_client.py
@@ -1,204 +1,215 @@
 import logging
+import re
+from http.cookies import SimpleCookie
 
 from aiohttp import ClientSession
-from .client_types import (
-    TrackerDevice,
-    One2TrackConfig,
-    AuthenticationError
-)
+
+from .client_types import AuthenticationError, One2TrackConfig, TrackerDevice
 
 _LOGGER = logging.getLogger(__name__)
 
-CONFIG = {
-    "login_url": "https://www.one2trackgps.com/auth/users/sign_in",
-    "base_url": "https://www.one2trackgps.com/",
-    "device_url": "https://www.one2trackgps.com/users/%account%/devices",
-    "session_cookie": "_iadmin"
-}
+BASE_URL = "https://www.one2trackgps.com"
+LOGIN_URL = f"{BASE_URL}/auth/users/sign_in"
+DEVICE_URL = f"{BASE_URL}/users/{{account_id}}/devices"
+SESSION_COOKIE = "_iadmin"
 
 
-class GpsClient():
-    config: One2TrackConfig
-    cookie: str = ""
-    csrf: str = ""
-    account_id: str
-
-    def __init__(self, config: One2TrackConfig, session: ClientSession):
+class GpsClient:
+    def __init__(self, config: One2TrackConfig, session: ClientSession) -> None:
         self.config = config
-        self.account_id = config.id  # might be empty
+        self.account_id: str = config.id or ""
         self.session = session
+        self._cookie: str = ""
+        self._csrf: str = ""
 
-    def set_account_id(self, account_id):
-        self.account_id = account_id
+    async def install(self) -> str:
+        await self._get_csrf()
+        await self._login()
+        return await self._get_user_id()
 
-    async def get_csrf(self):
-        login_page = await self.call_api(CONFIG["login_url"])
-        if login_page.status == 200:
-            html = await login_page.text()
-            self.csrf = self.parse_csrf(html)
-            _LOGGER.debug("[pre-login] Found CSRF token")
-            self.cookie = self.parse_cookie(login_page)
-            _LOGGER.debug("[pre-login] Found session cookie")
-        else:
-            _LOGGER.warning("[pre-login] Failed pre-login, response code: %s", login_page.status)
-            raise AuthenticationError("Login page unavailable")
+    async def update(self) -> list[TrackerDevice]:
+        await self._ensure_authenticated()
+        return await self._get_device_data()
 
-    async def call_api(self, url: str, data=None, allow_redirects=True, use_json=False, extra_headers=None):
-        headers = {}
-        cookies = {'accepted_cookies': 'true'}
+    async def power_off(self, device_uuid: str) -> bool:
+        """Shut down the device remotely."""
+        return await self._send_function(device_uuid, "0048", "Shutdown")
 
-        if data is not None:
-            headers["content-type"] = "application/x-www-form-urlencoded"
-
-        if use_json:
-            headers["content-type"] = "application/json"
-            headers["Accept"] = "application/json"
-
-        if extra_headers:
-            headers.update(extra_headers)
-
-        if self.cookie:
-            cookies['_iadmin'] = self.cookie
-
-        _LOGGER.debug('[http] %s %s %s', url, headers, cookies)
-
-        if data is not None:
-            return await self.session.post(url,
-                                           data=data,
-                                           headers=headers,
-                                           allow_redirects=allow_redirects,
-                                           cookies=cookies
-                                           )
-        else:
-            return await self.session.get(url, headers=headers, allow_redirects=allow_redirects, cookies=cookies)
-
-    def parse_cookie(self, response) -> str:
-        cookie = ""
-        if 'Set-Cookie' in response.headers:
-            cookie = response.headers['Set-Cookie']
-
-        if cookie:
-            return response.headers['Set-Cookie'].split(CONFIG["session_cookie"])[1].split(";")[
-                0].replace("=", "")
-        else:
-            _LOGGER.warning("No new cookie found, old cookie: %s", self.cookie)
-            return ""
-
-    def parse_csrf(self, html) -> str:
-        return html.split("name=\"csrf-token\" content=\"")[1].split("\"")[0]
-
-    async def login(self):
-        login_data = {
-            "authenticity_token": self.csrf,
-            "user[login]": self.config.username,
-            "user[password]": self.config.password,
-            "gdpr": "1",
-            "user[remember_me]": "1",
-        }
-        response = await self.call_api(CONFIG["login_url"], data=login_data, allow_redirects=False)
-
-        _LOGGER.debug("[login] Status: %s", response.status)
-
-        # login is successful when we get a fresh cookie
-        if response.status == 302 and "Set-Cookie" in response.headers:
-            _LOGGER.debug("[login] login success!")
-            self.cookie = self.parse_cookie(response)
-            _LOGGER.debug("[login] Got new session cookie")
-        else:
-            _LOGGER.warning("[login] Failed to login, response code: %s", response.status)
-            raise AuthenticationError("Invalid username or password")
-
-    async def get_user_id(self):
-        response = await self.call_api(CONFIG["base_url"], allow_redirects=False)
-        url = response.headers['Location']
-        account_id = url.split('/')[4]
-        _LOGGER.debug("[install] Extracted account id from redirect")
-        self.set_account_id(account_id)
-        return account_id
-
-    async def install(self):
-        await self.get_csrf()
-        await self.login()
-        return await self.get_user_id()
-
-    async def _ensure_authenticated(self):
-        """Ensure we have a valid session."""
-        if not self.cookie:
-            _LOGGER.debug("No session, logging in")
-            await self.get_csrf()
-            await self.login()
-            await self.get_user_id()
-
-    async def _get_csrf_token(self) -> str:
-        """Get a fresh CSRF token for action endpoints."""
-        response = await self.call_api(CONFIG["login_url"])
-        if response.status == 200:
-            html = await response.text()
-            # Update session cookie if the server sends a new one
-            new_cookie = self.parse_cookie(response)
-            if new_cookie:
-                self.cookie = new_cookie
-            return self.parse_csrf(html)
-        raise AuthenticationError("Could not get CSRF token")
+    async def force_update(self, device_uuid: str) -> bool:
+        """Activate positioning mode on the device for ~2 minutes."""
+        return await self._send_function(device_uuid, "0039", "Actieve positioneringmodus")
 
     async def send_message(self, device_uuid: str, message: str) -> bool:
         """Send a text message to a One2Track device."""
         await self._ensure_authenticated()
-        csrf = await self._get_csrf_token()
+        csrf = await self._fresh_csrf_token()
 
-        url = f"https://www.one2trackgps.com/devices/{device_uuid}/messages"
-
+        url = f"{BASE_URL}/devices/{device_uuid}/messages"
         headers = {
             "x-csrf-token": csrf,
             "content-type": "application/x-www-form-urlencoded;charset=UTF-8",
             "accept": "text/vnd.turbo-stream.html, text/html, application/xhtml+xml",
         }
-
         data = {
-            "utf8": "\u2713",
+            "utf8": "✓",
             "authenticity_token": csrf,
             "device_message[message]": message,
         }
 
-        response = await self.call_api(url, data=data, extra_headers=headers)
+        response = await self._request(url, data=data, extra_headers=headers)
         return response.status == 200
 
-    async def force_update(self, device_uuid: str) -> bool:
-        """Activate positioning mode on the device for ~2 minutes."""
+    # ------------------------------------------------------------------
+    # Internal auth flow
+    # ------------------------------------------------------------------
+
+    async def _ensure_authenticated(self) -> None:
+        if not self._cookie:
+            _LOGGER.debug("No session cookie, performing login")
+            await self._get_csrf()
+            await self._login()
+            await self._get_user_id()
+
+    async def _get_csrf(self) -> None:
+        response = await self._request(LOGIN_URL)
+        if response.status != 200:
+            raise AuthenticationError("Login page unavailable")
+
+        html = await response.text()
+        self._csrf = self._parse_csrf(html)
+        cookie = self._extract_cookie(response)
+        if cookie:
+            self._cookie = cookie
+
+    async def _login(self) -> None:
+        login_data = {
+            "authenticity_token": self._csrf,
+            "user[login]": self.config.username,
+            "user[password]": self.config.password,
+            "gdpr": "1",
+            "user[remember_me]": "1",
+        }
+        response = await self._request(LOGIN_URL, data=login_data, allow_redirects=False)
+
+        if response.status == 302:
+            new_cookie = self._extract_cookie(response)
+            if new_cookie:
+                self._cookie = new_cookie
+                return
+
+        raise AuthenticationError("Invalid username or password")
+
+    async def _get_user_id(self) -> str:
+        response = await self._request(f"{BASE_URL}/", allow_redirects=False)
+        if response.status != 302 or "Location" not in response.headers:
+            raise AuthenticationError("Could not determine account ID")
+
+        location = response.headers["Location"]
+        self.account_id = location.split("/")[4]
+        return self.account_id
+
+    async def _fresh_csrf_token(self) -> str:
+        """Fetch a fresh CSRF token (needed before each action request)."""
+        response = await self._request(LOGIN_URL)
+        if response.status != 200:
+            raise AuthenticationError("Could not get CSRF token")
+
+        html = await response.text()
+        new_cookie = self._extract_cookie(response)
+        if new_cookie:
+            self._cookie = new_cookie
+        return self._parse_csrf(html)
+
+    async def _send_function(self, device_uuid: str, code: str, name: str) -> bool:
+        """Send a function command to a device."""
         await self._ensure_authenticated()
-        csrf = await self._get_csrf_token()
+        csrf = await self._fresh_csrf_token()
 
-        url = f"https://www.one2trackgps.com/api/devices/{device_uuid}/functions"
-
+        url = f"{BASE_URL}/api/devices/{device_uuid}/functions"
         headers = {
             "x-csrf-token": csrf,
             "x-requested-with": "XMLHttpRequest",
             "content-type": "application/x-www-form-urlencoded; charset=UTF-8",
         }
-
         data = {
-            "utf8": "\u2713",
-            "function[code]": "0039",
-            "function[name]": "Actieve positioneringmodus",
+            "utf8": "✓",
+            "function[code]": code,
+            "function[name]": name,
         }
 
-        response = await self.call_api(url, data=data, extra_headers=headers)
+        response = await self._request(url, data=data, extra_headers=headers)
         return response.status == 200
 
-    async def update(self) -> list[TrackerDevice]:
-        await self._ensure_authenticated()
-        return await self.get_device_data()
-
-    async def get_device_data(self) -> list[TrackerDevice]:
-        url = CONFIG["device_url"].replace("%account%", self.account_id)
-        response = await self.call_api(url, use_json=True)
+    async def _get_device_data(self) -> list[TrackerDevice]:
+        url = DEVICE_URL.format(account_id=self.account_id)
+        response = await self._request(url, use_json=True)
 
         if response.status != 200:
-            _LOGGER.error("[one2track] Cannot get devices, code: %s", response.status)
-            self.cookie = ""
-            self.csrf = ""
+            _LOGGER.error("Cannot get devices, status %s", response.status)
+            self._cookie = ""
+            self._csrf = ""
             raise AuthenticationError(f"API returned status {response.status}")
 
         data = await response.json(content_type=None)
-        _LOGGER.debug("[devices] Got %s devices", len(data))
-        return [item['device'] for item in data]
+        _LOGGER.debug("Got %s devices", len(data))
+        return [item["device"] for item in data]
+
+    # ------------------------------------------------------------------
+    # HTTP helper — sends cookies via raw header to avoid session jar issues
+    # ------------------------------------------------------------------
+
+    async def _request(
+        self,
+        url: str,
+        *,
+        data: dict | None = None,
+        allow_redirects: bool = True,
+        use_json: bool = False,
+        extra_headers: dict | None = None,
+    ):
+        headers: dict[str, str] = {}
+
+        if data is not None:
+            headers["content-type"] = "application/x-www-form-urlencoded"
+        if use_json:
+            headers["content-type"] = "application/json"
+            headers["Accept"] = "application/json"
+        if extra_headers:
+            headers.update(extra_headers)
+
+        # Build cookie header manually so the session's cookie jar
+        # never interferes with our authentication state.
+        cookie_parts = ["accepted_cookies=true"]
+        if self._cookie:
+            cookie_parts.append(f"{SESSION_COOKIE}={self._cookie}")
+        headers["Cookie"] = "; ".join(cookie_parts)
+
+        _LOGGER.debug("[http] %s", url)
+
+        if data is not None:
+            return await self.session.post(
+                url, data=data, headers=headers, allow_redirects=allow_redirects
+            )
+        return await self.session.get(url, headers=headers, allow_redirects=allow_redirects)
+
+    # ------------------------------------------------------------------
+    # Parsing helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _extract_cookie(response) -> str:
+        """Extract the session cookie from a response's Set-Cookie headers."""
+        for header_value in response.headers.getall("Set-Cookie", []):
+            sc = SimpleCookie()
+            sc.load(header_value)
+            if SESSION_COOKIE in sc and sc[SESSION_COOKIE].value:
+                return sc[SESSION_COOKIE].value
+        return ""
+
+    @staticmethod
+    def _parse_csrf(html: str) -> str:
+        """Extract the CSRF token from a login page's HTML."""
+        m = re.search(r'name="csrf-token"\s+content="([^"]+)"', html)
+        if not m:
+            raise AuthenticationError("CSRF token not found on page")
+        return m.group(1)

--- a/custom_components/one2track/config_flow.py
+++ b/custom_components/one2track/config_flow.py
@@ -1,27 +1,17 @@
 import logging
 
+import homeassistant.helpers.config_validation as cv
+import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-import voluptuous as vol
-import homeassistant.helpers.config_validation as cv
 
-from .common import (
-    DOMAIN,
-    CONF_USER_NAME,
-    CONF_PASSWORD,
-    CONF_ID
-)
-from .client import (
-    get_client,
-    One2TrackConfig,
-    AuthenticationError
-)
+from .client import AuthenticationError, One2TrackConfig, get_client
+from .common import CONF_ID, CONF_PASSWORD, CONF_USER_NAME, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
 
 class One2TrackConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
-
     # For future migration support
     VERSION = 1
 
@@ -31,13 +21,14 @@ class One2TrackConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input:
             try:
                 session = async_get_clientsession(self.hass)
-                config = One2TrackConfig(username=user_input[CONF_USER_NAME], password=user_input[CONF_PASSWORD])
+                config = One2TrackConfig(
+                    username=user_input[CONF_USER_NAME],
+                    password=user_input[CONF_PASSWORD],
+                )
                 client = get_client(config, session)
                 account_id = await client.install()
 
-                _LOGGER.info(
-                    "One2Track GPS: Found account: %s", account_id
-                )
+                _LOGGER.info("One2Track GPS: Found account: %s", account_id)
 
                 user_input[CONF_ID] = account_id
                 await self.async_set_unique_id(user_input[CONF_ID])
@@ -53,10 +44,7 @@ class One2TrackConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="user",
             data_schema=vol.Schema(
-                {
-                    vol.Required(CONF_USER_NAME): cv.string,
-                    vol.Required(CONF_PASSWORD): cv.string
-                }
+                {vol.Required(CONF_USER_NAME): cv.string, vol.Required(CONF_PASSWORD): cv.string}
             ),
             errors=errors,
         )

--- a/custom_components/one2track/coordinator.py
+++ b/custom_components/one2track/coordinator.py
@@ -10,7 +10,7 @@ from homeassistant.helpers.update_coordinator import (
 )
 from homeassistant.util import dt as dt_util
 
-from .client import GpsClient, AuthenticationError
+from .client import AuthenticationError, GpsClient
 from .common import DEFAULT_UPDATE_RATE_MIN
 
 LOGGER = logging.getLogger(__name__)
@@ -23,7 +23,7 @@ class GpsCoordinator(DataUpdateCoordinator):
             LOGGER,
             name="One2Track",
             update_interval=timedelta(minutes=DEFAULT_UPDATE_RATE_MIN),
-            always_update=False
+            always_update=False,
         )
         self.gps_api = gps_api
         self.last_update = None

--- a/custom_components/one2track/device_tracker.py
+++ b/custom_components/one2track/device_tracker.py
@@ -1,11 +1,11 @@
 import logging
 
+from homeassistant.components.device_tracker.config_entry import TrackerEntity
+from homeassistant.components.zone import async_active_zone
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.components.zone import async_active_zone
-from homeassistant.components.device_tracker.config_entry import TrackerEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .client import TrackerDevice
@@ -16,24 +16,21 @@ LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
-        hass: HomeAssistant,
-        entry: ConfigEntry,
-        async_add_entities: AddEntitiesCallback,
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Add an entry."""
     LOGGER.debug("one2track async_setup_entry")
 
-    coordinator: GpsCoordinator = hass.data[DOMAIN][entry.entry_id]['coordinator']
+    coordinator: GpsCoordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
 
     devices: list[TrackerDevice] = coordinator.data or []
 
     LOGGER.info("Adding %s found one2track devices", len(devices))
 
     async_add_entities(
-        [
-            One2TrackDeviceTracker(coordinator, hass, device)
-            for device in devices
-        ],
+        [One2TrackDeviceTracker(coordinator, hass, device) for device in devices],
         update_before_add=False,
     )
 
@@ -44,20 +41,17 @@ class One2TrackDeviceTracker(CoordinatorEntity, TrackerEntity):
     _device: TrackerDevice
 
     def __init__(
-            self,
-            coordinator: GpsCoordinator,
-            hass: HomeAssistant,
-            device: TrackerDevice
+        self, coordinator: GpsCoordinator, hass: HomeAssistant, device: TrackerDevice
     ) -> None:
         super().__init__(coordinator)
         self._hass = hass
         self._device = device
-        self._attr_unique_id = device['uuid']
+        self._attr_unique_id = device["uuid"]
 
     @property
     def name(self):
         """Return the name of the device."""
-        return self._device['name']
+        return self._device["name"]
 
     @property
     def source_type(self):
@@ -67,18 +61,18 @@ class One2TrackDeviceTracker(CoordinatorEntity, TrackerEntity):
     @property
     def location_accuracy(self):
         """Return the gps accuracy of the device in meters."""
-        meta = self._device.get('last_location', {}).get('meta_data')
-        if meta and 'accuracy_meters' in meta:
-            return meta['accuracy_meters']
+        meta = self._device.get("last_location", {}).get("meta_data")
+        if meta and "accuracy_meters" in meta:
+            return meta["accuracy_meters"]
         return 10
 
     @property
     def device_info(self) -> DeviceInfo:
         """Return the device_info of the device."""
         return DeviceInfo(
-            identifiers={(DOMAIN, self._device['uuid'])},
-            serial_number=self._device['serial_number'],
-            name=self._device['name'],
+            identifiers={(DOMAIN, self._device["uuid"])},
+            serial_number=self._device["serial_number"],
+            name=self._device["name"],
         )
 
     @property
@@ -88,27 +82,25 @@ class One2TrackDeviceTracker(CoordinatorEntity, TrackerEntity):
     @property
     def extra_state_attributes(self):
         """Return device specific attributes."""
-        location = self._device.get('last_location', {})
-        simcard = self._device.get('simcard', {})
+        location = self._device.get("last_location", {})
+        simcard = self._device.get("simcard", {})
         return {
-            "serial_number": self._device['serial_number'],
-            "uuid": self._device['uuid'],
-            "name": self._device['name'],
-
-            "status": self._device['status'],
-            "phone_number": self._device['phone_number'],
-            "tariff_type": simcard.get('tariff_type'),
-            "balance_cents": simcard.get('balance_cents'),
-
-            "last_communication": location.get('last_communication'),
-            "last_location_update": location.get('last_location_update'),
-            "altitude": location.get('altitude'),
-            "location_type": location.get('location_type'),
-            "address": location.get('address'),
-            "signal_strength": location.get('signal_strength'),
-            "satellite_count": location.get('satellite_count'),
-            "host": location.get('host'),
-            "port": location.get('port'),
+            "serial_number": self._device["serial_number"],
+            "uuid": self._device["uuid"],
+            "name": self._device["name"],
+            "status": self._device["status"],
+            "phone_number": self._device["phone_number"],
+            "tariff_type": simcard.get("tariff_type"),
+            "balance_cents": simcard.get("balance_cents"),
+            "last_communication": location.get("last_communication"),
+            "last_location_update": location.get("last_location_update"),
+            "altitude": location.get("altitude"),
+            "location_type": location.get("location_type"),
+            "address": location.get("address"),
+            "signal_strength": location.get("signal_strength"),
+            "satellite_count": location.get("satellite_count"),
+            "host": location.get("host"),
+            "port": location.get("port"),
         }
 
     @property
@@ -129,12 +121,12 @@ class One2TrackDeviceTracker(CoordinatorEntity, TrackerEntity):
         except Exception as err:
             LOGGER.error("Cannot get zone for tracker: %s", err)
 
-        return self._device.get('last_location', {}).get('address')
+        return self._device.get("last_location", {}).get("address")
 
     @property
     def latitude(self):
         """Return latitude value of the device."""
-        val = self._device.get('last_location', {}).get('latitude')
+        val = self._device.get("last_location", {}).get("latitude")
         if val is not None:
             try:
                 return float(val)
@@ -145,7 +137,7 @@ class One2TrackDeviceTracker(CoordinatorEntity, TrackerEntity):
     @property
     def longitude(self):
         """Return longitude value of the device."""
-        val = self._device.get('last_location', {}).get('longitude')
+        val = self._device.get("last_location", {}).get("longitude")
         if val is not None:
             try:
                 return float(val)
@@ -158,7 +150,7 @@ class One2TrackDeviceTracker(CoordinatorEntity, TrackerEntity):
         """Respond to a DataUpdateCoordinator update."""
         new_data: list[TrackerDevice] = self.coordinator.data
         if new_data:
-            me = next((x for x in new_data if x['uuid'] == self.unique_id), None)
+            me = next((x for x in new_data if x["uuid"] == self.unique_id), None)
             if me:
                 self._device = me
             else:

--- a/custom_components/one2track/sensor.py
+++ b/custom_components/one2track/sensor.py
@@ -31,6 +31,7 @@ LOGGER = logging.getLogger(__name__)
 @dataclass(frozen=True, kw_only=True)
 class One2TrackSensorDescription(SensorEntityDescription):
     """Describes a One2Track sensor."""
+
     value_fn: Callable[[TrackerDevice], Any]
 
 
@@ -195,21 +196,19 @@ SENSOR_DESCRIPTIONS: list[One2TrackSensorDescription] = [
 
 
 async def async_setup_entry(
-        hass: HomeAssistant,
-        entry: ConfigEntry,
-        async_add_entities: AddEntitiesCallback,
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up One2Track sensor entities."""
-    coordinator: GpsCoordinator = hass.data[DOMAIN][entry.entry_id]['coordinator']
+    coordinator: GpsCoordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
 
     devices: list[TrackerDevice] = coordinator.data or []
 
     entities = []
     for device in devices:
         for description in SENSOR_DESCRIPTIONS:
-            entities.append(
-                One2TrackSensorEntity(coordinator, device, description)
-            )
+            entities.append(One2TrackSensorEntity(coordinator, device, description))
 
     async_add_entities(entities)
 
@@ -221,10 +220,10 @@ class One2TrackSensorEntity(CoordinatorEntity, SensorEntity):
     _attr_has_entity_name = True
 
     def __init__(
-            self,
-            coordinator: GpsCoordinator,
-            device: TrackerDevice,
-            description: One2TrackSensorDescription,
+        self,
+        coordinator: GpsCoordinator,
+        device: TrackerDevice,
+        description: One2TrackSensorDescription,
     ) -> None:
         super().__init__(coordinator)
         self.entity_description = description
@@ -234,9 +233,9 @@ class One2TrackSensorEntity(CoordinatorEntity, SensorEntity):
     @property
     def device_info(self) -> DeviceInfo:
         return DeviceInfo(
-            identifiers={(DOMAIN, self._device['uuid'])},
-            serial_number=self._device['serial_number'],
-            name=self._device['name'],
+            identifiers={(DOMAIN, self._device["uuid"])},
+            serial_number=self._device["serial_number"],
+            name=self._device["name"],
         )
 
     @property
@@ -247,7 +246,7 @@ class One2TrackSensorEntity(CoordinatorEntity, SensorEntity):
     def _handle_coordinator_update(self) -> None:
         new_data: list[TrackerDevice] = self.coordinator.data
         if new_data:
-            me = next((x for x in new_data if x['uuid'] == self._device['uuid']), None)
+            me = next((x for x in new_data if x["uuid"] == self._device["uuid"]), None)
             if me:
                 self._device = me
         self.async_write_ha_state()

--- a/custom_components/one2track/services.py
+++ b/custom_components/one2track/services.py
@@ -13,6 +13,7 @@ LOGGER = logging.getLogger(__name__)
 
 SERVICE_SEND_MESSAGE = "send_message"
 SERVICE_FORCE_UPDATE = "force_update"
+SERVICE_POWER_OFF = "power_off"
 ATTR_MESSAGE = "message"
 
 
@@ -35,8 +36,9 @@ def _resolve_device_uuid(hass: HomeAssistant, entity_ids: list[str]) -> str:
                 coordinator = entry_data.get("coordinator")
                 if coordinator and coordinator.data:
                     for device in coordinator.data:
-                        if unique_id == device.get("uuid") or unique_id.startswith(device.get("uuid", "") + "_"):
-                            return device["uuid"]
+                        device_uuid = device.get("uuid", "")
+                        if unique_id == device_uuid or unique_id.startswith(f"{device_uuid}_"):
+                            return device_uuid
             # Fall back to raw unique_id if no coordinator match
             return unique_id
 
@@ -97,23 +99,51 @@ async def async_setup_services(hass: HomeAssistant) -> None:
             if coordinator:
                 await coordinator.async_request_refresh()
 
+    async def handle_power_off(call: ServiceCall) -> None:
+        entity_ids = call.data.get("entity_id", [])
+        if isinstance(entity_ids, str):
+            entity_ids = [entity_ids]
+
+        device_uuid = _resolve_device_uuid(hass, entity_ids)
+        client = _get_client_for_uuid(hass, device_uuid)
+
+        LOGGER.info("Sending power off to %s", device_uuid)
+        success = await client.power_off(device_uuid)
+        if not success:
+            raise HomeAssistantError("Failed to power off One2Track device")
+
     hass.services.async_register(
         DOMAIN,
         SERVICE_SEND_MESSAGE,
         handle_send_message,
-        schema=vol.Schema({
-            vol.Required("entity_id"): vol.Any(str, [str]),
-            vol.Required(ATTR_MESSAGE): str,
-        }),
+        schema=vol.Schema(
+            {
+                vol.Required("entity_id"): vol.Any(str, [str]),
+                vol.Required(ATTR_MESSAGE): str,
+            }
+        ),
     )
 
     hass.services.async_register(
         DOMAIN,
         SERVICE_FORCE_UPDATE,
         handle_force_update,
-        schema=vol.Schema({
-            vol.Required("entity_id"): vol.Any(str, [str]),
-        }),
+        schema=vol.Schema(
+            {
+                vol.Required("entity_id"): vol.Any(str, [str]),
+            }
+        ),
+    )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_POWER_OFF,
+        handle_power_off,
+        schema=vol.Schema(
+            {
+                vol.Required("entity_id"): vol.Any(str, [str]),
+            }
+        ),
     )
 
 
@@ -121,3 +151,4 @@ async def async_unload_services(hass: HomeAssistant) -> None:
     """Unload One2Track services."""
     hass.services.async_remove(DOMAIN, SERVICE_SEND_MESSAGE)
     hass.services.async_remove(DOMAIN, SERVICE_FORCE_UPDATE)
+    hass.services.async_remove(DOMAIN, SERVICE_POWER_OFF)

--- a/custom_components/one2track/services.yaml
+++ b/custom_components/one2track/services.yaml
@@ -21,3 +21,11 @@ force_update:
     entity:
       integration: one2track
       domain: device_tracker
+
+power_off:
+  name: Power off
+  description: Remotely shut down a One2Track device
+  target:
+    entity:
+      integration: one2track
+      domain: device_tracker

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,25 @@
+[project]
+name = "one2track"
+version = "1.1.0"
+description = "Home Assistant integration for One2Track GPS watches"
+requires-python = ">=3.12"
+dependencies = [
+    "aiohttp>=3.9",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24",
+    "pytest-cov>=6.0",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"
+
+[tool.ruff]
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "UP"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,32 @@
+"""Pytest configuration for One2Track tests."""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+# Add the repo root to sys.path so custom_components is importable
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+# Mock homeassistant and its submodules so the client package can be imported
+# without a full HA installation
+ha_mock = MagicMock()
+sys.modules.setdefault("homeassistant", ha_mock)
+sys.modules.setdefault("homeassistant.config_entries", ha_mock)
+sys.modules.setdefault("homeassistant.core", ha_mock)
+sys.modules.setdefault("homeassistant.const", ha_mock)
+sys.modules.setdefault("homeassistant.exceptions", ha_mock)
+sys.modules.setdefault("homeassistant.helpers", ha_mock)
+sys.modules.setdefault("homeassistant.helpers.aiohttp_client", ha_mock)
+sys.modules.setdefault("homeassistant.helpers.config_validation", ha_mock)
+sys.modules.setdefault("homeassistant.helpers.device_registry", ha_mock)
+sys.modules.setdefault("homeassistant.helpers.entity_platform", ha_mock)
+sys.modules.setdefault("homeassistant.helpers.entity_registry", ha_mock)
+sys.modules.setdefault("homeassistant.helpers.update_coordinator", ha_mock)
+sys.modules.setdefault("homeassistant.components.zone", ha_mock)
+sys.modules.setdefault("homeassistant.components.device_tracker", ha_mock)
+sys.modules.setdefault("homeassistant.components.device_tracker.config_entry", ha_mock)
+sys.modules.setdefault("homeassistant.components.sensor", ha_mock)
+sys.modules.setdefault("homeassistant.components.binary_sensor", ha_mock)
+sys.modules.setdefault("homeassistant.util", ha_mock)
+sys.modules.setdefault("homeassistant.util.dt", ha_mock)
+sys.modules.setdefault("voluptuous", MagicMock())

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,149 @@
+"""Tests for authentication and cookie/CSRF parsing."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.one2track.client.client_types import (
+    AuthenticationError,
+    One2TrackConfig,
+)
+from custom_components.one2track.client.gps_client import GpsClient
+
+
+class TestParseCsrf:
+    def test_extracts_token(self):
+        html = '<meta name="csrf-token" content="abc123XYZ+/==" />'
+        assert GpsClient._parse_csrf(html) == "abc123XYZ+/=="
+
+    def test_extracts_token_with_whitespace_variations(self):
+        html = '<meta name="csrf-token"  content="token123">'
+        assert GpsClient._parse_csrf(html) == "token123"
+
+    def test_raises_on_missing_token(self):
+        with pytest.raises(AuthenticationError, match="CSRF token not found"):
+            GpsClient._parse_csrf("<html><body>no token here</body></html>")
+
+    def test_raises_on_empty_html(self):
+        with pytest.raises(AuthenticationError, match="CSRF token not found"):
+            GpsClient._parse_csrf("")
+
+
+class TestExtractCookie:
+    def _make_response(self, set_cookie_headers: list[str]):
+        response = MagicMock()
+        response.headers = MagicMock()
+        response.headers.getall = MagicMock(return_value=set_cookie_headers)
+        return response
+
+    def test_extracts_from_set_cookie(self):
+        resp = self._make_response(["_iadmin=abc123; path=/; HttpOnly; SameSite=Lax"])
+        assert GpsClient._extract_cookie(resp) == "abc123"
+
+    def test_extracts_from_multiple_set_cookie_headers(self):
+        resp = self._make_response(
+            [
+                "accepted_cookies=true; path=/",
+                "_iadmin=session_value; path=/; HttpOnly",
+            ]
+        )
+        assert GpsClient._extract_cookie(resp) == "session_value"
+
+    def test_returns_empty_when_no_session_cookie(self):
+        resp = self._make_response(["other_cookie=val; path=/"])
+        assert GpsClient._extract_cookie(resp) == ""
+
+    def test_returns_empty_when_no_headers(self):
+        resp = self._make_response([])
+        assert GpsClient._extract_cookie(resp) == ""
+
+    def test_ignores_empty_cookie_value(self):
+        resp = self._make_response(["_iadmin=; path=/; HttpOnly"])
+        assert GpsClient._extract_cookie(resp) == ""
+
+
+class TestLoginFlow:
+    @pytest.mark.asyncio
+    async def test_install_sets_account_id(self):
+        config = One2TrackConfig(username="user", password="pass")
+        session = AsyncMock()
+
+        csrf_response = MagicMock()
+        csrf_response.status = 200
+        csrf_response.text = AsyncMock(return_value='<meta name="csrf-token" content="csrf123" />')
+        csrf_response.headers = MagicMock()
+        csrf_response.headers.getall = MagicMock(
+            return_value=["_iadmin=session1; path=/; HttpOnly"]
+        )
+
+        login_response = MagicMock()
+        login_response.status = 302
+        login_response.headers = MagicMock()
+        login_response.headers.getall = MagicMock(
+            return_value=["_iadmin=session2; path=/; HttpOnly"]
+        )
+
+        redirect_response = MagicMock()
+        redirect_response.status = 302
+        redirect_response.headers = {
+            "Location": "https://www.one2trackgps.com/users/myaccount/devices"
+        }
+
+        session.get = AsyncMock(side_effect=[csrf_response, redirect_response])
+        session.post = AsyncMock(return_value=login_response)
+
+        client = GpsClient(config, session)
+        account_id = await client.install()
+
+        assert account_id == "myaccount"
+        assert client.account_id == "myaccount"
+        assert client._cookie == "session2"
+
+    @pytest.mark.asyncio
+    async def test_login_raises_on_non_302(self):
+        config = One2TrackConfig(username="user", password="wrong")
+        session = AsyncMock()
+
+        csrf_response = MagicMock()
+        csrf_response.status = 200
+        csrf_response.text = AsyncMock(return_value='<meta name="csrf-token" content="csrf123" />')
+        csrf_response.headers = MagicMock()
+        csrf_response.headers.getall = MagicMock(return_value=["_iadmin=sess; path=/"])
+
+        login_response = MagicMock()
+        login_response.status = 200
+        login_response.headers = MagicMock()
+        login_response.headers.getall = MagicMock(return_value=[])
+
+        session.get = AsyncMock(return_value=csrf_response)
+        session.post = AsyncMock(return_value=login_response)
+
+        client = GpsClient(config, session)
+
+        with pytest.raises(AuthenticationError, match="Invalid username"):
+            await client.install()
+
+
+class TestRequestCookieHeader:
+    @pytest.mark.asyncio
+    async def test_sends_cookie_via_header_not_kwarg(self):
+        config = One2TrackConfig(username="user", password="pass", id="acc")
+        session = AsyncMock()
+
+        response = MagicMock()
+        response.status = 200
+        response.json = AsyncMock(return_value=[])
+        session.get = AsyncMock(return_value=response)
+
+        client = GpsClient(config, session)
+        client._cookie = "my_session_token"
+
+        await client._get_device_data()
+
+        call_args = session.get.call_args
+        headers = call_args[1]["headers"]
+        assert "Cookie" in headers
+        assert "_iadmin=my_session_token" in headers["Cookie"]
+        assert "accepted_cookies=true" in headers["Cookie"]
+        # No cookies= kwarg should be passed
+        assert "cookies" not in call_args[1]

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,0 +1,85 @@
+"""Tests for device command services (power_off, force_update)."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.one2track.client.client_types import One2TrackConfig
+from custom_components.one2track.client.gps_client import GpsClient
+
+
+class TestSendFunction:
+    @pytest.fixture
+    def client(self):
+        config = One2TrackConfig(username="user", password="pass", id="test_id")
+        session = AsyncMock()
+        c = GpsClient(config, session)
+        c._cookie = "existing_session"
+        return c
+
+    @pytest.mark.asyncio
+    async def test_power_off_sends_correct_code(self, client):
+        mock_csrf_response = MagicMock()
+        mock_csrf_response.status = 200
+        mock_csrf_response.text = AsyncMock(
+            return_value='<meta name="csrf-token" content="csrf_tok" />'
+        )
+        mock_csrf_response.headers = MagicMock()
+        mock_csrf_response.headers.getall = MagicMock(return_value=[])
+
+        mock_func_response = MagicMock()
+        mock_func_response.status = 200
+
+        client.session.get = AsyncMock(return_value=mock_csrf_response)
+        client.session.post = AsyncMock(return_value=mock_func_response)
+
+        result = await client.power_off("device-uuid-123")
+
+        assert result is True
+        call_args = client.session.post.call_args
+        assert "api/devices/device-uuid-123/functions" in call_args[0][0]
+        post_data = call_args[1]["data"]
+        assert post_data["function[code]"] == "0048"
+        assert post_data["function[name]"] == "Shutdown"
+
+    @pytest.mark.asyncio
+    async def test_force_update_sends_correct_code(self, client):
+        mock_csrf_response = MagicMock()
+        mock_csrf_response.status = 200
+        mock_csrf_response.text = AsyncMock(
+            return_value='<meta name="csrf-token" content="csrf_tok" />'
+        )
+        mock_csrf_response.headers = MagicMock()
+        mock_csrf_response.headers.getall = MagicMock(return_value=[])
+
+        mock_func_response = MagicMock()
+        mock_func_response.status = 200
+
+        client.session.get = AsyncMock(return_value=mock_csrf_response)
+        client.session.post = AsyncMock(return_value=mock_func_response)
+
+        result = await client.force_update("device-uuid-456")
+
+        assert result is True
+        call_args = client.session.post.call_args
+        assert "api/devices/device-uuid-456/functions" in call_args[0][0]
+        post_data = call_args[1]["data"]
+        assert post_data["function[code]"] == "0039"
+        assert post_data["function[name]"] == "Actieve positioneringmodus"
+
+    @pytest.mark.asyncio
+    async def test_returns_false_on_non_200(self, client):
+        mock_csrf_response = MagicMock()
+        mock_csrf_response.status = 200
+        mock_csrf_response.text = AsyncMock(return_value='<meta name="csrf-token" content="tok" />')
+        mock_csrf_response.headers = MagicMock()
+        mock_csrf_response.headers.getall = MagicMock(return_value=[])
+
+        mock_func_response = MagicMock()
+        mock_func_response.status = 422
+
+        client.session.get = AsyncMock(return_value=mock_csrf_response)
+        client.session.post = AsyncMock(return_value=mock_func_response)
+
+        result = await client.power_off("device-uuid")
+        assert result is False


### PR DESCRIPTION
## Summary

- **Fix login on HA's shared session** — rewrites cookie handling to send cookies via raw `Cookie` header instead of the `cookies=` kwarg, bypassing aiohttp's cookie jar entirely. This fixes the authentication failures reported in #15 and #16 where HA's shared `ClientSession` absorbed Set-Cookie headers into its jar before they could be read back.
- **Add `power_off` service** — sends function code `0048` to remotely shut down a device, using the same entity-targeting pattern as `force_update` and `send_message`.
- **Code quality** — regex-based CSRF parsing, proper error handling, `_send_function` helper to DRY command dispatch, ruff formatting, and unit tests (15 total).

## Approach

The root cause of #15/#16 is that `async_get_clientsession(hass)` returns a shared session whose cookie jar can interfere with cookie-based auth flows. Rather than switching to a dedicated session (which goes against HA conventions), the client now manages cookies entirely through the `Cookie` request header and reads them from `Set-Cookie` response headers via `http.cookies.SimpleCookie`. The session's cookie jar is never involved.

## Test plan

- [x] Unit tests pass (`pytest tests/` — 15 tests covering auth flow, cookie extraction, CSRF parsing, function codes)
- [x] Lint clean (`ruff check` + `ruff format`)
- [x] Deployed to live HA instance, integration loads with `async_get_clientsession`
- [x] `one2track.force_update` service call works end-to-end
- [x] `one2track.power_off` verified to shut down a watch

🤖 Generated with [Claude Code](https://claude.com/claude-code)