### PR TITLE
Fix re-authentication failure caused by shared session cookie jar

### DIFF
--- a/custom_components/one2track/__init__.py
+++ b/custom_components/one2track/__init__.py
@@ -3,9 +3,8 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .client import AuthenticationError, One2TrackConfig, get_client
+from .client import AuthenticationError, GpsClient, One2TrackConfig, get_client
 from .common import CONF_ID, CONF_PASSWORD, CONF_USER_NAME, DOMAIN, LOGGER
 from .coordinator import GpsCoordinator
 from .services import async_setup_services, async_unload_services
@@ -16,13 +15,12 @@ PLATFORMS = [Platform.DEVICE_TRACKER, Platform.SENSOR, Platform.BINARY_SENSOR]
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up One2Track Data from a config entry."""
 
-    session = async_get_clientsession(hass)
     config = One2TrackConfig(
         username=entry.data[CONF_USER_NAME],
         password=entry.data[CONF_PASSWORD],
         id=entry.data[CONF_ID],
     )
-    api = get_client(config, session)
+    api = get_client(config)
     try:
         account_id = await api.install()
     except (ClientError, AuthenticationError) as ex:
@@ -56,7 +54,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id)
+        entry_data = hass.data[DOMAIN].pop(entry.entry_id)
+        client: GpsClient = entry_data.get("api_client")
+        if client and hasattr(client, "session"):
+            await client.session.close()
         if not hass.data[DOMAIN]:
             await async_unload_services(hass)
 

--- a/custom_components/one2track/client/__init__.py
+++ b/custom_components/one2track/client/__init__.py
@@ -1,4 +1,4 @@
-from aiohttp import ClientSession
+from aiohttp import ClientSession, DummyCookieJar
 
 from .client_types import AuthenticationError as AuthenticationError
 from .client_types import One2TrackConfig as One2TrackConfig
@@ -6,5 +6,7 @@ from .client_types import TrackerDevice as TrackerDevice
 from .gps_client import GpsClient as GpsClient
 
 
-def get_client(config: One2TrackConfig, session: ClientSession) -> GpsClient:
+def get_client(config: One2TrackConfig, session: ClientSession | None = None) -> GpsClient:
+    if session is None:
+        session = ClientSession(cookie_jar=DummyCookieJar())
     return GpsClient(config, session)

--- a/custom_components/one2track/config_flow.py
+++ b/custom_components/one2track/config_flow.py
@@ -3,7 +3,6 @@ import logging
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
 from homeassistant import config_entries
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .client import AuthenticationError, One2TrackConfig, get_client
 from .common import CONF_ID, CONF_PASSWORD, CONF_USER_NAME, DOMAIN
@@ -12,20 +11,19 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class One2TrackConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
-    # For future migration support
     VERSION = 1
 
     async def async_step_user(self, user_input=None):
         errors = {}
         user_input = user_input or {}
         if user_input:
+            client = None
             try:
-                session = async_get_clientsession(self.hass)
                 config = One2TrackConfig(
                     username=user_input[CONF_USER_NAME],
                     password=user_input[CONF_PASSWORD],
                 )
-                client = get_client(config, session)
+                client = get_client(config)
                 account_id = await client.install()
 
                 _LOGGER.info("One2Track GPS: Found account: %s", account_id)
@@ -40,6 +38,9 @@ class One2TrackConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 )
             except AuthenticationError:
                 errors["base"] = "authentication_error"
+            finally:
+                if client and hasattr(client, "session"):
+                    await client.session.close()
 
         return self.async_show_form(
             step_id="user",


### PR DESCRIPTION
## Problem

The integration uses HA's shared `aiohttp.ClientSession` (via `async_get_clientsession`). This session's cookie jar accumulates One2Track session cookies during normal operation. When the server session expires (~12h) and the integration attempts to re-authenticate, stale cookies from the jar conflict with the manually set `Cookie` header in `_request()`, causing the Rails CSRF validation to fail.

**Symptom**: After ~12 hours of uptime, the coordinator logs `Invalid username or password` every update interval until HA is restarted. The credentials are correct — the initial login on startup works fine.

**Root cause**: aiohttp's session cookie jar sends its own cookies alongside the manual `Cookie` header. On re-authentication, the jar's stale `_iadmin` cookie interferes with the fresh cookie from the login flow.

## Fix

Use a dedicated `ClientSession` with `DummyCookieJar` (stores no cookies at all) instead of HA's shared session. Since the client already manages all cookies manually via request headers, the session's cookie jar should never participate. The dedicated session is properly closed on config entry unload.

Changes across 3 files, net +4 lines:
- `__init__.py` — remove `async_get_clientsession`, call `get_client(config)` without session arg, close session on unload
- `client/__init__.py` — create dedicated `ClientSession(cookie_jar=DummyCookieJar())` when no session provided
- `config_flow.py` — same pattern, with cleanup in `finally` block

## Testing

Simulated session expiry inside a running HA container by clearing the client's internal cookie state, then verified re-authentication succeeds and device data is fetched:

```
1. Login OK: rdeknijf
2. Devices: ['Balder', 'Freya']
3. Cleared cookies (simulating 12h expiry)
4. Re-auth + fetch OK: ['Balder', 'Freya']
```

Running this fix on my own HA instance (HA 2026.5.3, aiohttp 3.13.5, Python 3.14).

Fixes #19.